### PR TITLE
fix: Remove 'valid-jsdoc' rule from typescript config

### DIFF
--- a/.changeset/five-keys-sort.md
+++ b/.changeset/five-keys-sort.md
@@ -1,0 +1,5 @@
+---
+'@justoss/code-style': patch
+---
+
+Removed 'valid-jsdoc' rule from typescript config.

--- a/eslint-config-typescript.js
+++ b/eslint-config-typescript.js
@@ -42,6 +42,7 @@ module.exports = {
         'react/prop-types': 'off',
         'react/require-default-props': 'off',
         'require-jsdoc': 'off',
+        'valid-jsdoc': 'off',
       },
     },
     {


### PR DESCRIPTION
## Description

Removed 'valid-jsdoc' rule from typescript config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
